### PR TITLE
Fix macOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/cmake-build**/
+/.idea**/

--- a/build-post.h
+++ b/build-post.h
@@ -32,8 +32,12 @@
 extern "C" {
 #endif
 #include "defs.h"
-#include "dirent.h"
 
+#ifdef __APPLE__
+  #include <dirent.h>
+#else
+  #include "dirent.h"
+#endif
 /*
  * Text domain name.
  */

--- a/build-pre.h
+++ b/build-pre.h
@@ -44,8 +44,10 @@
 #include "unistd.h"
 #include <fcntl.h>
 
-#ifdef HAVE_DIRECT_H
-#include <direct.h>
+#ifndef __APPLE__
+  #ifdef HAVE_DIRECT_H
+  #include <direct.h>
+  #endif
 #endif
 
 #ifdef HAVE__GETDCWD

--- a/filename.c
+++ b/filename.c
@@ -33,8 +33,11 @@
 #include "build-post.h"
 
 
+#ifdef __APPLE__
+#include <dirent.h>
+#else
 #include "dirent.h"
-
+#endif
 
 
 #ifndef DOS_FILE_PATH

--- a/unistd.h
+++ b/unistd.h
@@ -4,6 +4,11 @@ unistd.h maps (roughly) to io.h
 */
 #ifndef _UNISTD_H
 #define _UNISTD_H
+
+#ifdef __APPLE__
+#include <unistd.h>
+#elifdef
 #include <io.h>
 #include <process.h>
+#endif
 #endif /* _UNISTD_H */


### PR DESCRIPTION
`dirent.h` and `unistd.h` are standard UNIX headers. The system already provides one.

Changes are just wrapper over original #includes

None-APPLE shouldn't be affected