### PR TITLE
chore(ci): update checkout version and remove path filters

### DIFF
--- a/.github/workflows/auto format.yml
+++ b/.github/workflows/auto format.yml
@@ -4,22 +4,17 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "winlibs/**"
   push:
     branches:
       - main
-    paths-ignore:
-      - "winlibs/**"
 permissions:
   contents: read
 jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4
         with:
-
           fetch-depth: 2
       # format the latest commit
       - name: ubuntu install clang-format
@@ -29,5 +24,3 @@ jobs:
           (/home/linuxbrew/.linuxbrew/opt/clang-format/bin/git-clang-format --binary=/home/linuxbrew/.linuxbrew/opt/clang-format/bin/clang-format --style=file HEAD^) || true
 
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
-
-

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Linux: install zlib via apt
     - name: Install zlib (Linux)
@@ -58,4 +58,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-


### PR DESCRIPTION
This PR updates the checkout action to v4 for better performance and removes the paths-ignore restriction in the auto-format workflow to ensure all directories are covered.