### PR TITLE
Remove ENABLE_NLS (NLS/gettext) support

### DIFF
--- a/build-pre.h
+++ b/build-pre.h
@@ -151,4 +151,3 @@ typedef intptr_t ssize_t;
 #endif
 
 #endif /* EB_BUILD_PRE_H */
-

--- a/build-pre.h
+++ b/build-pre.h
@@ -115,19 +115,10 @@ typedef intptr_t ssize_t;
 #define ASCII_TOLOWER(c) (('A' <= (c) && (c) <= 'Z') ? (c) + 0x20 : (c))
 
 /*
- * Tricks for gettext.
+ * Macros for gettext (always disabled; NLS not supported).
  */
-#ifdef ENABLE_NLS
-#define _(string) gettext(string)
-#ifdef gettext_noop
-#define N_(string) gettext_noop(string)
-#else
-#define N_(string) (string)
-#endif
-#else
 #define _(string) (string)
 #define N_(string) (string)
-#endif
 
 /*
  * Fake missing function names.
@@ -160,3 +151,4 @@ typedef intptr_t ssize_t;
 #endif
 
 #endif /* EB_BUILD_PRE_H */
+

--- a/eb.c
+++ b/eb.c
@@ -45,9 +45,6 @@ eb_initialize_library(void)
     LOG(("aux: EB Library version %s", EB_VERSION_STRING));
 
     eb_initialize_default_hookset();
-#ifdef ENABLE_NLS
-    bindtextdomain(EB_TEXT_DOMAIN_NAME, EB_LOCALEDIR);
-#endif
 
     if (zio_initialize_library() < 0) {
 	error_code = EB_ERR_MEMORY_EXHAUSTED;

--- a/error.c
+++ b/error.c
@@ -31,7 +31,6 @@
 #include "error.h"
 #include "build-post.h"
 
-
 /*
  * Error code strings.
  */

--- a/error.c
+++ b/error.c
@@ -270,9 +270,5 @@ eb_error_message(EB_Error_Code error_code)
     else
         message = N_("unknown error");
 
-#ifdef ENABLE_NLS
-    message = dgettext(EB_TEXT_DOMAIN_NAME, message);
-#endif /* ENABLE_NLS */
-
     return message;
 }

--- a/error.c
+++ b/error.c
@@ -31,12 +31,6 @@
 #include "error.h"
 #include "build-post.h"
 
-/*
- * Mutex for gettext function call.
- */
-#if defined(ENABLE_NLS) && defined(ENABLE_PTHREAD)
-pthread_mutex_t gettext_mutex = PTHREAD_MUTEX_INITIALIZER;
-#endif
 
 /*
  * Error code strings.


### PR DESCRIPTION
- build-pre.h: Remove ENABLE_NLS conditional block, simplify _( ) and N_( ) macros to always return the string as-is (no gettext translation)
- error.c: Remove gettext mutex (ENABLE_NLS + ENABLE_PTHREAD) and dgettext() call in eb_error_message()
- eb.c: Remove bindtextdomain() call in eb_initialize_library()