### PR TITLE
clean: remove unused S_ISREG/S_ISDIR and network compatibility macros

### DIFF
--- a/build-pre.h
+++ b/build-pre.h
@@ -83,16 +83,6 @@ typedef intptr_t ssize_t;
 #endif
 
 /*
- * stat() macros.
- */
-#ifndef S_ISREG
-#define S_ISREG(m)   (((m) & S_IFMT) == S_IFREG)
-#endif
-#ifndef S_ISDIR
-#define S_ISDIR(m)   (((m) & S_IFMT) == S_IFDIR)
-#endif
-
-/*
  * Flags for open().
  */
 #ifndef O_BINARY
@@ -126,28 +116,6 @@ typedef intptr_t ssize_t;
 #ifndef HAVE_STRCASECMP
 #define strcasecmp eb_strcasecmp
 #define strncasecmp eb_strncasecmp
-#endif
-
-#ifndef HAVE_GETADDRINFO
-#define addrinfo ebnet_addrinfo
-#define getaddrinfo ebnet_getaddrinfo
-#define freeaddrinfo ebnet_freeaddrinfo
-#endif
-
-#ifndef HAVE_GETNAMEINFO
-#define getnameinfo ebnet_getnameinfo
-#endif
-
-#ifndef HAVE_GAI_STRERROR
-#define gai_strerror ebnet_gai_strerror
-#endif
-
-#ifndef IN6ADDR_ANY_DECLARED
-#define in6addr_any ebnet_in6addr_any
-#endif
-
-#ifndef IN6ADDR_LOOPBACK_DECLARED
-#define in6addr_loopback ebnet_in6addr_loopback
 #endif
 
 #endif /* EB_BUILD_PRE_H */


### PR DESCRIPTION
### Summary

Remove unused macros from \uild-pre.h\ that are no longer needed after recent refactoring.

### Changes

- **S_ISREG / S_ISDIR**: Windows \stat()\ compatibility macros — no longer required
- **HAVE_GETADDRINFO / HAVE_GETNAMEINFO / HAVE_GAI_STRERROR** and related network compatibility definitions — now obsolete

These were left over from the previous \win_msvc.h\ merge and network layer cleanup.