### PR TITLE
zio_open_raw: replace fixed 16384 wchar_t stack buffer with dynamic a…

### DIFF
--- a/zio.c
+++ b/zio.c
@@ -1960,18 +1960,18 @@ static int
 zio_open_raw(Zio *zio, const char *file_name)
 {
 #if defined( _WIN32 )
-    int wlen = MultiByteToWideChar(CP_UTF8, 0, file_name, -1, NULL, 0);
-    if (wlen == 0)
-        return -1;
-    wchar_t *wname = (wchar_t *)malloc((size_t)wlen * sizeof(wchar_t));
-    if (wname == NULL)
-        return -1;
-    if (MultiByteToWideChar(CP_UTF8, 0, file_name, -1, wname, wlen) == 0) {
-        free(wname);
-        return -1;
-    }
-    zio->file = _wopen(wname, _O_RDONLY | _O_BINARY);
+  int wlen = MultiByteToWideChar(CP_UTF8, 0, file_name, -1, NULL, 0);
+  if (wlen == 0)
+    return -1;
+  wchar_t *wname = (wchar_t *)malloc((size_t)wlen * sizeof(wchar_t));
+  if (wname == NULL)
+    return -1;
+  if (MultiByteToWideChar(CP_UTF8, 0, file_name, -1, wname, wlen) == 0) {
     free(wname);
+    return -1;
+  }
+  zio->file = _wopen(wname, _O_RDONLY | _O_BINARY);
+  free(wname);
 #else
     zio->file = open( file_name, O_RDONLY | O_BINARY );
 #endif

--- a/zio.c
+++ b/zio.c
@@ -1960,11 +1960,18 @@ static int
 zio_open_raw(Zio *zio, const char *file_name)
 {
 #if defined( _WIN32 )
-    wchar_t wname[ 16384 ];
-
-    if ( MultiByteToWideChar( CP_UTF8, 0, file_name, -1, wname, 16384 ) == 0 )
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, file_name, -1, NULL, 0);
+    if (wlen == 0)
         return -1;
-    zio->file = _wopen( wname, _O_RDONLY | _O_BINARY );
+    wchar_t *wname = (wchar_t *)malloc((size_t)wlen * sizeof(wchar_t));
+    if (wname == NULL)
+        return -1;
+    if (MultiByteToWideChar(CP_UTF8, 0, file_name, -1, wname, wlen) == 0) {
+        free(wname);
+        return -1;
+    }
+    zio->file = _wopen(wname, _O_RDONLY | _O_BINARY);
+    free(wname);
 #else
     zio->file = open( file_name, O_RDONLY | O_BINARY );
 #endif


### PR DESCRIPTION
…llocation

The original code allocated a fixed wchar_t[16384] (32 KB) on the stack for converting UTF-8 file names to wide-character strings on Windows. This was wasteful since typical paths are much shorter.

Now uses a two-step approach: first call MultiByteToWideChar with NULL output buffer to get the required size, then malloc exactly that amount. This eliminates the 32 KB stack allocation and handles arbitrarily long paths correctly.