### PR TITLE
fix: resolve MSVC C4293 shift count warnings for 32-bit off_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /cmake-build**/
 /.idea**/
+/.continue/

--- a/zio.c
+++ b/zio.c
@@ -26,17 +26,15 @@
  * SUCH DAMAGE.
  */
 
-
-
-#include <stdio.h>
-#include <sys/types.h>
+#include "custom_unistd.h"
 #include <errno.h>
-#include <string.h>
-#include <stdlib.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdint.h>
-#include "custom_unistd.h"
-#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
 
 #ifdef ENABLE_PTHREAD
 #include <pthread.h>
@@ -100,11 +98,12 @@ extern void eb_log(const char *, ...);
         + (*(const unsigned char *)((p) + 2) << 8) \
         + (*(const unsigned char *)((p) + 3)))
 
-#define zio_uint5(p) (((off_t) ((uint64_t)*(const unsigned char *)(p) << 32)) \
-	+ ((off_t) (*(const unsigned char *)((p) + 1)) << 24) \
-	+ (*(const unsigned char *)((p) + 2) << 16) \
-	+ (*(const unsigned char *)((p) + 3) << 8) \
-	+ (*(const unsigned char *)((p) + 4)))
+#define zio_uint5(p)                                                           \
+  (((off_t)((uint64_t)*(const unsigned char *)(p) << 32)) +                    \
+   ((off_t)(*(const unsigned char *)((p) + 1)) << 24) +                        \
+   (*(const unsigned char *)((p) + 2) << 16) +                                 \
+   (*(const unsigned char *)((p) + 3) << 8) +                                  \
+   (*(const unsigned char *)((p) + 4)))
 
 /*
  * Test whether the path is URL with the `ebnet' scheme.
@@ -166,8 +165,9 @@ static pthread_mutex_t zio_mutex = PTHREAD_MUTEX_INITIALIZER;
 /*
  * Test whether `off_t' represents a large integer.
  */
-#define off_t_is_large \
-	(((off_t) ((uint64_t)1 << 41) + (off_t) ((uint64_t)1 << 40) + 1) % 9999991 == 7852006)
+#define off_t_is_large                                                         \
+  (((off_t)((uint64_t)1 << 41) + (off_t)((uint64_t)1 << 40) + 1) % 9999991 ==  \
+   7852006)
 
 /*
  * Unexported function.
@@ -472,8 +472,8 @@ zio_open_ebzip(Zio *zio, const char *file_name)
 	zio->index_width = 2;
     else if (zio->file_size < (off_t) 1 << 24)
 	zio->index_width = 3;
-    else if (zio->file_size < (off_t) ((uint64_t)1 << 32) || !off_t_is_large)
-	zio->index_width = 4;
+    else if (zio->file_size < (off_t)((uint64_t)1 << 32) || !off_t_is_large)
+      zio->index_width = 4;
     else
 	zio->index_width = 5;
 
@@ -2069,6 +2069,3 @@ zio_read_raw(Zio *zio, void *buffer, size_t length)
     LOG(("out: zio_read_raw() = %ld", (long)-1));
     return -1;
 }
-
-
-

--- a/zio.c
+++ b/zio.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <stdint.h>
 #include "custom_unistd.h"
 #include <fcntl.h>
 
@@ -99,7 +100,7 @@ extern void eb_log(const char *, ...);
         + (*(const unsigned char *)((p) + 2) << 8) \
         + (*(const unsigned char *)((p) + 3)))
 
-#define zio_uint5(p) (((off_t) (*(const unsigned char *)(p)) << 32) \
+#define zio_uint5(p) (((off_t) ((uint64_t)*(const unsigned char *)(p) << 32)) \
 	+ ((off_t) (*(const unsigned char *)((p) + 1)) << 24) \
 	+ (*(const unsigned char *)((p) + 2) << 16) \
 	+ (*(const unsigned char *)((p) + 3) << 8) \
@@ -166,7 +167,7 @@ static pthread_mutex_t zio_mutex = PTHREAD_MUTEX_INITIALIZER;
  * Test whether `off_t' represents a large integer.
  */
 #define off_t_is_large \
-	((((off_t) 1 << 41) + ((off_t) 1 << 40) + 1) % 9999991 == 7852006)
+	(((off_t) ((uint64_t)1 << 41) + (off_t) ((uint64_t)1 << 40) + 1) % 9999991 == 7852006)
 
 /*
  * Unexported function.
@@ -471,7 +472,7 @@ zio_open_ebzip(Zio *zio, const char *file_name)
 	zio->index_width = 2;
     else if (zio->file_size < (off_t) 1 << 24)
 	zio->index_width = 3;
-    else if (zio->file_size < (off_t) 1 << 32 || !off_t_is_large)
+    else if (zio->file_size < (off_t) ((uint64_t)1 << 32) || !off_t_is_large)
 	zio->index_width = 4;
     else
 	zio->index_width = 5;
@@ -2068,5 +2069,6 @@ zio_read_raw(Zio *zio, void *buffer, size_t length)
     LOG(("out: zio_read_raw() = %ld", (long)-1));
     return -1;
 }
+
 
 

--- a/zio.c
+++ b/zio.c
@@ -2068,4 +2068,4 @@ zio_read_raw(Zio *zio, void *buffer, size_t length)
   failed:
     LOG(("out: zio_read_raw() = %ld", (long)-1));
     return -1;
-}
+  }


### PR DESCRIPTION
On MSVC, \off_t\ is defined as 32-bit \long\. Shifting by >=32 bits on a 32-bit type is undefined behavior, triggering 6 C4293 warnings.

Changes:
- Cast to \uint64_t\ before left-shifting by >=32 bits in \zio_uint5\ macro
- Use \uint64_t\ for large shifts in \off_t_is_large\ macro
- Use \uint64_t\ before \(off_t)\ cast in \(off_t)1<<32\ comparison
- Add \#include <stdint.h>\ for \uint64_t\
- Add \/.continue/\ to \.gitignore\

No functional changes — only intermediate computation is widened to avoid undefined behavior.