### PR TITLE
refactor: remove unnecessary header includes from build-pre.h

### DIFF
--- a/zio.c
+++ b/zio.c
@@ -26,6 +26,7 @@
  * SUCH DAMAGE.
  */
 
+#include "build-pre.h"
 #include "custom_unistd.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -35,7 +36,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include "build-pre.h"
 
 #ifdef ENABLE_PTHREAD
 #include <pthread.h>

--- a/zio.c
+++ b/zio.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include "build-pre.h"
 
 #ifdef ENABLE_PTHREAD
 #include <pthread.h>

--- a/zio.h
+++ b/zio.h
@@ -33,7 +33,6 @@
 extern "C" {
 #endif
 
-
 #include <sys/types.h>
 #include <time.h>
 

--- a/zio.h
+++ b/zio.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#include "build-pre.h"
+
 #include <sys/types.h>
 #include <time.h>
 


### PR DESCRIPTION
Removed redundant standard library includes that are not directly used by any definitions or macros in uild-pre.h itself. These headers are already included by the individual source files that need them.
